### PR TITLE
#81 - Removing celery queue name so the task can be handled by defaul…

### DIFF
--- a/server_py/flatgov/flatgov/celery.py
+++ b/server_py/flatgov/flatgov/celery.py
@@ -45,13 +45,11 @@ app.conf.beat_schedule = {
     },
     'download_sources': {
         'task': 'events.tasks.download_sources',
-        'schedule': crontab(minute=0, hour=19),
-        'options': {'queue': 'event'}
+        'schedule': crontab(minute=0, hour=19)
     },
     'process_sources': {
         'task': 'events.tasks.process_sources',
-        'schedule': crontab(minute=5, hour=19),
-        'options': {'queue': 'event'}
+        'schedule': crontab(minute=5, hour=19)
     },
     'update_cosponsor': {
         'task': 'bills.tasks.update_cosponsor_comm_task',


### PR DESCRIPTION
…t celery worker in prod

Default celery worker is currently running in prod
deploying this change should allow this task to be run on the existing celery worker in prod, without additional changes