### PR TITLE
#208 3c - Adding CSS style to Reason column to capitalize the first l…

### DIFF
--- a/server_py/flatgov/templates/bills/detail.html
+++ b/server_py/flatgov/templates/bills/detail.html
@@ -301,9 +301,9 @@
                                     {% endif %}
                                     {% with bill.number_of_sections as number_of_sections %}
                                         {% if number_of_sections %}
-                                            <td>{{ bill.reason|add_number_of_sections:number_of_sections }}</td>
+                                            <td class="text-capitalize">{{ bill.reason|add_number_of_sections:number_of_sections }}</td>
                                         {% else %}
-                                            <td>{{ bill.reason|add_number_of_sections:0 }}</td>
+                                            <td class="text-capitalize">{{ bill.reason|add_number_of_sections:0 }}</td>
                                         {% endif %}
                                     {% endwith %}
                                     <td>

--- a/server_py/flatgov/templates/bills/detail.html
+++ b/server_py/flatgov/templates/bills/detail.html
@@ -359,9 +359,9 @@
                                     {% endif %}
                                     {% with bill.number_of_sections as number_of_sections %}
                                         {% if number_of_sections %}
-                                            <td>{{ bill.reason|add_number_of_sections:number_of_sections }}</td>
+                                            <td class="text-capitalize">{{ bill.reason|add_number_of_sections:number_of_sections }}</td>
                                         {% else %}
-                                            <td>{{ bill.reason|add_number_of_sections:0 }}</td>
+                                            <td class="text-capitalize">{{ bill.reason|add_number_of_sections:0 }}</td>
                                         {% endif %}
                                     {% endwith %}
                                     <td>


### PR DESCRIPTION
…etter of each word

I kept the data intact and used CSS to capitalize the first letter of each word in the reason column
The CSS is a bootstrap class name

Pure styling fix, so it should be an easy pull request

FYI,
I noticed a case on my local http://localhost:8000/bills/113sjres24
where the Reason is just Identical, but there is a comma after it "Identical,"
See attached-

<img width="975" alt="Screen Shot 2021-07-02 at 5 55 43 PM" src="https://user-images.githubusercontent.com/2983868/124332137-c3018e80-db5e-11eb-8c85-f547c2572a7e.png">

